### PR TITLE
Upgrade peer deps angular 16

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rt-ng2-smart-table",
-  "version": "1.7.5",
+  "version": "1.7.6",
   "scripts": {
     "ng": "ng",
     "start": "ng serve",

--- a/projects/ng2-smart-table/package.json
+++ b/projects/ng2-smart-table/package.json
@@ -1,17 +1,17 @@
 {
   "name": "rt-ng2-smart-table",
-  "version": "1.7.6",
+  "version": "1.7.7",
   "description": "Angular Smart Table",
   "author": "akveo",
   "license": "MIT",
   "dependencies": {
     "lodash": "^4.17.21",
-    "tslib": "^2.4.0"
+    "tslib": "^2.6.3"
   },
   "peerDependencies": {
     "ng2-completer": "^9.0.1",
-    "@angular/common": "^15.2.9",
-    "@angular/core": "^15.2.9",
-    "@angular/forms": "^15.2.9"
+    "@angular/common": "^16.2.12",
+    "@angular/core": "^16.2.12",
+    "@angular/forms": "^16.2.12"
   }
 }

--- a/projects/ng2-smart-table/package.json
+++ b/projects/ng2-smart-table/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rt-ng2-smart-table",
-  "version": "1.7.5",
+  "version": "1.7.6",
   "description": "Angular Smart Table",
   "author": "akveo",
   "license": "MIT",
@@ -10,8 +10,8 @@
   },
   "peerDependencies": {
     "ng2-completer": "^9.0.1",
-    "@angular/common": "^14.0.0",
-    "@angular/core": "^14.0.0",
-    "@angular/forms": "^14.0.0"
+    "@angular/common": "^15.2.9",
+    "@angular/core": "^15.2.9",
+    "@angular/forms": "^15.2.9"
   }
 }


### PR DESCRIPTION
Problem: We are trying to upgrade the angular version of admin but this table lists angular 15 as a dependency. 

Solution: Upgrade the dependencies in the package.json of this repo so that we can upgrade angular. Note this will be a series of upgrades since I need to upgrade to the next angular version until I reach version 18. This PR will upgrade the angular dependency to version 16. lodash and tslib are also updated according to their latest release from npmjs.com